### PR TITLE
Explain refreshes, touch up css

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,10 @@ function App() {
           {/* render default navbar if URL is empty */}
           <Route exact path="/">
             <div className="navbar">
-              <Navbar subtitle={getHeader()} />
+              <Navbar 
+                path="/" 
+                subtitle={getHeader()} 
+              />
             </div>
           </Route>
           {/* pass in URL through params if it's not the default URL */}
@@ -27,7 +30,10 @@ function App() {
             path="/:currentPage"
             render={(input) => (
               <div className="navbar">
-                <Navbar subtitle={getHeader(input.match.params.currentPage)} />
+                <Navbar 
+                  path={input.match.params.currentPage} 
+                  subtitle={getHeader(input.match.params.currentPage)} 
+                />
               </div>
             )}
           ></Route>

--- a/src/AppMain.css
+++ b/src/AppMain.css
@@ -39,6 +39,14 @@
   align-items: flex-end;
 }
 
+.title-link {
+  margin: 0 1.5rem 0 0;
+  color: white;
+}
+.title-link:hover {
+  text-decoration: none;
+}
+
 .title {
   font-size: min(8vw, 2.5rem);
   margin: 0 1rem 0 0;
@@ -93,6 +101,10 @@
   align-items: center;
   justify-content: space-between;
   padding: 30px 0;
+}
+
+button {
+  cursor: pointer;
 }
 
 button:focus {

--- a/src/components/mainContent/Navbar.css
+++ b/src/components/mainContent/Navbar.css
@@ -15,7 +15,7 @@
   position: absolute;
   min-width: 120px;
   height: 450px;
-  margin-top: 70px;
+  margin-top: 69px;
 }
 
 .dropdown-content {
@@ -55,4 +55,17 @@
   height: 55px;
   position: relative;
   right: -2px;
+  cursor: pointer;
+}
+
+.nav-button-image:hover {
+  filter: brightness(85%);
+}
+
+.rotate {
+  transform: rotate(180deg);
+}
+
+.current-link {
+  background-color: #ddd;
 }

--- a/src/components/mainContent/Navbar.js
+++ b/src/components/mainContent/Navbar.js
@@ -24,7 +24,7 @@ export default function NavBar(props) {
         onClick={dropdownHandler}
       >
         <img
-          className="nav-button-image"
+          className={`nav-button-image ${dropdownOpen && `rotate`}`}
           src={navButton}
           alt="arrow to expand table of contents"
         ></img>
@@ -32,13 +32,27 @@ export default function NavBar(props) {
           <div className="dropdown">
             <div className="dropdown-content">
               <nav>
-                <Link to="/">Landing Page</Link>
-                <Link to="/aboutUs">About Us</Link>
-                <Link to="/college">Case Study #1</Link>
-                <Link to="/facebook">Case Study #2</Link>
-                <Link to="/facialRecognition">Case Study #3</Link>
-                <Link to="/conclusion">Conclusion</Link>
-                <Link to="/resources">Resources</Link>
+                <Link className={props.path === '/' && 'current-link'} to="/">
+                  Landing Page
+                </Link>
+                <Link className={props.path === 'aboutUs' && 'current-link'} to="/aboutUs">
+                  About Us
+                </Link>
+                <Link className={props.path === 'college' && 'current-link'} to="/college">
+                  Case Study #1
+                </Link>
+                <Link className={props.path === 'facebook' && 'current-link'} to="/facebook">
+                  Case Study #2
+                </Link>
+                <Link className={props.path === 'facialRecognition' && 'current-link'} to="/facialRecognition">
+                  Case Study #3
+                </Link>
+                <Link className={props.path === 'conclusion' && 'current-link'} to="/conclusion">
+                  Conclusion
+                </Link>
+                <Link className={props.path === 'resources' && 'current-link'} to="/resources">
+                  Resources
+                </Link>
               </nav>
             </div>
           </div>
@@ -58,7 +72,9 @@ export default function NavBar(props) {
       </a>
       {/* 'Bias by Us' will be a link -- clicking on it will go to the introduction page of our learning lab */}
       <div className="title-container">
-        <h1 className="title">Bias by Us</h1>
+        <Link className="title-link" to="/">
+          <h1 className="title">Bias by Us</h1>
+        </Link>
         <h2 className="subtitle">{props.subtitle}</h2>
       </div>
       {dropdownArea()}

--- a/src/components/mainContent/ProgressBar.js
+++ b/src/components/mainContent/ProgressBar.js
@@ -17,7 +17,11 @@ export default function ProgressBar(props) {
                    - duration: total duration of the scroll animation
                 */
                 <Link activeClass="active" to={section.post.header} smooth={true} offset={-100} duration={500} className='progress-button' key ={index} aria-label={`move to ${section.post.header}`}>
-                    <img className={`profile-pic no-margin static-size ${props.content.indexOf(section) > props.visibleSections ? "gray" : ""}`} src={section.post.profilePic} alt={`the icon for the "${section.post.header}" section`}/>
+                    <img 
+                        className={`profile-pic no-margin static-size ${props.content.indexOf(section) > props.visibleSections ? "gray" : ""}`} 
+                        src={section.post.profilePic} 
+                        alt={`the icon for the "${section.post.header}" section`}
+                    />
                 </Link>
             );
         });

--- a/src/components/mainContent/commonLogic.js
+++ b/src/components/mainContent/commonLogic.js
@@ -23,7 +23,7 @@ export function useWindowDimensions() {
     }
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resizeWidth", handleResize);
-  }, [windowWidth, windowHeight]);
+  }, []);
 
   return [windowWidth, windowHeight];
 }

--- a/src/components/mainContent/mainContent.css
+++ b/src/components/mainContent/mainContent.css
@@ -45,6 +45,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 }
 
 .forward-button:active {
@@ -80,12 +81,14 @@
 .static-size {
   width: 65px;
   height: 65px;
+  cursor: pointer;
 }
 
 .gray {
   opacity: 0.5;
   filter: alpha(opacity=40);
   filter: grayscale(1);
+  cursor: default;
 }
 
 /* for the triangle inside ForwardButton, since the triangle is blue by default due to the Navbar button */

--- a/src/components/posts/Facebook/socialMedia/AdDisplay.js
+++ b/src/components/posts/Facebook/socialMedia/AdDisplay.js
@@ -5,7 +5,9 @@ export default function AdDisplay(props){
     if (props.selectedAd === "default")
         return (
             <div id ="shown-ad">
-                Select a section to display its ad
+                <p>Imagine the user scrolling through their home feed and seeing a job ad.</p> 
+                <p>The histogram below displays the frequency of different ads the user might see each time they refresh their feed.</p>
+                <p>Simulate some refreshes, and then click on a bar to view the corresponding ad!</p>
             </div>
         )
     return (

--- a/src/components/posts/Facebook/socialMedia/socialMedia.css
+++ b/src/components/posts/Facebook/socialMedia/socialMedia.css
@@ -109,6 +109,8 @@
 #shown-ad {
   height: 600px;
   display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
   align-items: center;
   padding: 10px;
 }


### PR DESCRIPTION
closes #23, #27

- `AdDisplay` now explains what "refreshes" mean
- add `cursor: pointer` to things that the cursor should point to (e.g. buttons, links)
- removed `[windowWidth, windowHeight]` from a useEffect in `commonLogic.js`
- navbar button darkens a little on hover, flips direction onclick
- current section is highlighted grey by default in the dropdown menu