### PR TITLE
(#40 Alternative) Memoization for ProgressBar display logic, fixed cleanup effects

### DIFF
--- a/src/caseStudies/CaseStudyFacebook.js
+++ b/src/caseStudies/CaseStudyFacebook.js
@@ -1,19 +1,31 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import "../AppMain.css";
 import PostsList from "../components/mainContent/PostsList";
 import labContent from "../assets/labContent";
 import { useWindowDimensions } from "../components/mainContent/commonLogic";
 import ProgressBar from "../components/mainContent/ProgressBar";
 
+//HOC that is less expensive to re-render with memoization than entire component tree
 function CaseStudyFacebook() {
+  const [windowWidth] = useWindowDimensions();
+  const [displayProgress, setDisplayProgress] = useState(true);
+
+  useEffect(() => {
+    setDisplayProgress(windowWidth > 1300);
+  }, [windowWidth]);
+  return <FacebookContent displayProgress={displayProgress} />;
+}
+
+/*The Memoized Page only rerenders whenever the displayProgress prop changes, 
+which is handled by the HOC above*/
+const FacebookContent = React.memo(function FacebookContent(props) {
   const [visibleSections, setVisibleSections] = useState(0);
   const [currentVisibleText, setCurrentVisibleText] = useState(0);
   const [forwardVisible, setForwardVisible] = useState(false);
-  const [windowWidth] = useWindowDimensions();
 
   return (
     <div className="app">
-      {windowWidth > 1300 && (
+      {props.displayProgress && (
         <ProgressBar
           content={labContent}
           visibleSections={visibleSections}
@@ -37,5 +49,5 @@ function CaseStudyFacebook() {
       </div>
     </div>
   );
-}
+});
 export default CaseStudyFacebook;

--- a/src/components/mainContent/commonLogic.js
+++ b/src/components/mainContent/commonLogic.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 
 /*a custom hook that returns an array containing the windowWidth and windowHeight 
 updated by changes in browser for use by navbars or case studies*/
+
 export function useWindowDimensions() {
   const [windowWidth, setWindowWidth] = useState(getWindowWidth());
   const [windowHeight, setWindowHeight] = useState(getWindowHeight());
@@ -22,7 +23,7 @@ export function useWindowDimensions() {
       setWindowHeight(getWindowHeight());
     }
     window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resizeWidth", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   return [windowWidth, windowHeight];


### PR DESCRIPTION
By creating a Higher Order Component that handles whether or not the progress bar should be displayed and separating `CaseStudyFacebook` into `CaseStudyFacebook` and `FacebookContent` , the number of re-renders for the entire page's content is reduced significantly which improves webpage performance.

Also fixed the return function inside of `useWindowDimensions` to properly remove our event listener.

New Render Profiling Stats:

![memoizedValue](https://user-images.githubusercontent.com/65370631/119209326-e2cf6e00-ba5a-11eb-8f4b-34e6ebd75bac.png)

Old Render Profiling Stats: 

![memoizationProfiler](https://user-images.githubusercontent.com/65370631/119209338-eebb3000-ba5a-11eb-9b70-71bf78747d1e.png)
