### PR TITLE
Restructured Code Instead of Memoization

### DIFF
--- a/src/caseStudies/CaseStudyFacebook.js
+++ b/src/caseStudies/CaseStudyFacebook.js
@@ -2,26 +2,20 @@ import React, { useState } from "react";
 import "../AppMain.css";
 import PostsList from "../components/mainContent/PostsList";
 import labContent from "../assets/labContent";
-import { useWindowDimensions } from "../components/mainContent/commonLogic";
 import ProgressBar from "../components/mainContent/ProgressBar";
-
 function CaseStudyFacebook() {
   const [visibleSections, setVisibleSections] = useState(0);
   const [currentVisibleText, setCurrentVisibleText] = useState(0);
   const [forwardVisible, setForwardVisible] = useState(false);
-  const [windowWidth] = useWindowDimensions();
-
   return (
     <div className="app">
-      {windowWidth > 1300 && (
-        <ProgressBar
-          content={labContent}
-          visibleSections={visibleSections}
-          setVisibleSections={setVisibleSections}
-          setForwardVisible={setForwardVisible}
-          setCurrentVisibleText={setCurrentVisibleText}
-        />
-      )}
+      <ProgressBar
+        content={labContent}
+        visibleSections={visibleSections}
+        setVisibleSections={setVisibleSections}
+        setForwardVisible={setForwardVisible}
+        setCurrentVisibleText={setCurrentVisibleText}
+      />
 
       <div className="posts">
         <PostsList

--- a/src/components/mainContent/ProgressBar.js
+++ b/src/components/mainContent/ProgressBar.js
@@ -3,32 +3,48 @@ import "../../AppMain.css";
 import "../../index.css";
 import "../posts/posts.css";
 import "./mainContent.css";
-import {Link} from "react-scroll";
+import { useWindowDimensions } from "./commonLogic";
+import { Link } from "react-scroll";
 
 export default function ProgressBar(props) {
+  const [windowWidth] = useWindowDimensions();
 
-    const indices = [0, 1, 3, 5, 7, 9];
-    let content = props.content.filter((s, index) => indices.includes(index))
-        .map((section, index) => {
-            return (
-                /* scrollTo configuration options:
-                   - smooth: animates the scrolling with smooth movement
-                   - offset: scroll additional px (like padding), so that we can see the content under the navbar
-                   - duration: total duration of the scroll animation
-                */
-                <Link activeClass="active" to={section.post.header} smooth={true} offset={-100} duration={500} className='progress-button' key ={index} aria-label={`move to ${section.post.header}`}>
-                    <img 
-                        className={`profile-pic no-margin static-size ${props.content.indexOf(section) > props.visibleSections ? "gray" : ""}`} 
-                        src={section.post.profilePic} 
-                        alt={`the icon for the "${section.post.header}" section`}
-                    />
-                </Link>
-            );
-        });
+  const indices = [0, 1, 3, 5, 7, 9];
+  let content = props.content
+    .filter((s, index) => indices.includes(index))
+    .map((section, index) => {
+      return (
+        /* scrollTo configuration options:
+            - smooth: animates the scrolling with smooth movement
+            - offset: scroll additional px (like padding), so that we can see the content under the navbar
+            - duration: total duration of the scroll animation
+        */
+        <Link
+          activeClass="active"
+          to={section.post.header}
+          smooth={true}
+          offset={-100}
+          duration={500}
+          className="progress-button"
+          key={index}
+          aria-label={`move to ${section.post.header}`}
+        >
+          <img
+            className={`profile-pic no-margin static-size ${
+              props.content.indexOf(section) > props.visibleSections
+                ? "gray"
+                : ""
+            }`}
+            src={section.post.profilePic}
+            alt={`the icon for the "${section.post.header}" section`}
+          />
+        </Link>
+      );
+    });
 
-    return (
-        <div className="progress-bar">
-            {content} 
-        </div>
-    );
+  /*conditionally render either null or the progress bar 
+  depending on the window width */
+  return windowWidth > 1300 ? (
+    <div className="progress-bar">{content}</div>
+  ) : null;
 }

--- a/src/components/mainContent/commonLogic.js
+++ b/src/components/mainContent/commonLogic.js
@@ -22,7 +22,7 @@ export function useWindowDimensions() {
       setWindowHeight(getWindowHeight());
     }
     window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resizeWidth", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   return [windowWidth, windowHeight];


### PR DESCRIPTION
The memoization in the previous pull request  (#38 ) was primarily used to reduce the amount of times post-list was forced to re-render by memoizing logic.

However, memoization should only be used after trying to restructure code first. By moving the `useWindowWidth` logic from `CaseStudyFacebook` to `ProgressBar` we improve performance to similar levels by not requiring `PostList` to re-render without resorting to memoization, which reduces the overhead data that we have to store within the heap.

With this approach, `PostList` never has to re-render, only `ProgressBar`.

`PostList` Rendering Stats:

![codeRestructureProfiling](https://user-images.githubusercontent.com/65370631/119250386-a122ee00-bb54-11eb-92cd-4ea1002bc2f6.png)

`ProgressBar` Rendering Stats

![comparableTime](https://user-images.githubusercontent.com/65370631/119249456-88fba080-bb4d-11eb-9603-8407208eaecd.png)
