### PR TITLE
Adjusted lambda handler to accept http requests

### DIFF
--- a/cloud-models/gender-word-embeddings/handler.py
+++ b/cloud-models/gender-word-embeddings/handler.py
@@ -28,7 +28,7 @@ def lambda_handler(event, context):
     """
 
     WORD_WEIGHT = 100
-    word = event['word']
+    word = event['queryStringParameters']['word']
     if word is None:
         return {
         'statusCode':400,


### PR DESCRIPTION
Properly fixed the handler of our lambda function to accept lambda-proxy integration from API Gateway as opposed to raw function calls like before

JSON return of when we call 
https://FUNCTION_URL?word=test
<img width="256" alt="Screen Shot 2021-08-17 at 12 57 17 AM" src="https://user-images.githubusercontent.com/65370631/129687068-e9edbe00-c826-47f9-898f-0597349234ed.png">
