### PR TITLE
Adjusted neutral word boundaries to account for edge cases

### DIFF
--- a/website/src/components/posts/CollegeAdmissions/essay/ScatterPlot.js
+++ b/website/src/components/posts/CollegeAdmissions/essay/ScatterPlot.js
@@ -39,8 +39,8 @@ export default function ScatterPlot(props) {
   /*If the heScore/sheScore are within 5% of each other */
   const equalSelected = selected.filter(
     (wordObj) =>
-      wordObj.heScore - wordObj.sheScore < 5 &&
-      wordObj.heScore - wordObj.sheScore > -5
+      wordObj.heScore - wordObj.sheScore <= 5 &&
+      wordObj.heScore - wordObj.sheScore >= -5
   );
   const listOfScatters = [];
   //append heLeaning words


### PR DESCRIPTION
Changed neutral word boundaries from `<` and `>` to `<=` and `>=` since currently, if they're exactly on the boundary then they are not shown on the graph at all.