### PR TITLE
edited gender graph's y axis label name and format

### DIFF
--- a/website/src/components/posts/Facebook/genderGraph/GenderGraphContainer.js
+++ b/website/src/components/posts/Facebook/genderGraph/GenderGraphContainer.js
@@ -26,19 +26,14 @@ export default function GenderGraphContainer() {
       >
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="name" dy={5} fontSize="1.1rem" />
-        <YAxis
-          fontSize="1.1rem"
-          tickFormatter={(tick) => {
-            // formats y-axis labels to have '%'
-            return `${tick}%`;
-          }}
-        />
+        <YAxis fontSize="1.1rem" unit="%" />
         <Tooltip />
         <Line
           type="monotone"
-          dataKey="percentage"
+          dataKey="women enrolled"
           stroke="#68b068"
           activeDot={{ r: 8 }}
+          unit="%"
         />
       </LineChart>
     </ResponsiveContainer>

--- a/website/src/components/posts/Facebook/genderGraph/graphData.js
+++ b/website/src/components/posts/Facebook/genderGraph/graphData.js
@@ -4,7 +4,7 @@ const data = percentages.map((p) => {
   year += 5; // years will range from 1965 to 2020
   return {
     name: year,
-    percentage: p,
+    "women enrolled": p,
   };
 });
 


### PR DESCRIPTION
closes #70 

the y axis is now labeled "women enrolled", and the datapoint in the hover label is formatted to have a % sign
sample datapoint:
```
1960
women enrolled: 15%
```