### PR TITLE
addressed text spacing issues of `Written Essay` with spans

### DIFF
--- a/website/src/components/posts/CollegeAdmissions/essay/EssayContainer.js
+++ b/website/src/components/posts/CollegeAdmissions/essay/EssayContainer.js
@@ -12,7 +12,7 @@ import "./essay.css";
 const INITIAL_WORD_LENGTH = 3;
 const wordSections = [
   {
-    plain: "This is our example",
+    plain: "This is our example ",
   },
   {
     changeable: ["essay", "activity", "game"],
@@ -20,7 +20,8 @@ const wordSections = [
     sheScores: [5, 10, 15],
   },
   {
-    plain: "made by our devs! What's your favorite",
+    plain:
+      "made by our devs! Our devs really enjoy cooking a lot of different foods. I'm curious, what's your favorite",
   },
   {
     changeable: ["meal", "food", "dish"],
@@ -31,7 +32,7 @@ const wordSections = [
     plain: "to cook? I know that I love",
   },
   {
-    changeable: ["fried rice", "spam masubi", "sushi"],
+    changeable: ["fried rice", "spam", "sushi"],
     heScores: [10, 20, 30],
     sheScores: [5, 10, 15],
   },

--- a/website/src/components/posts/CollegeAdmissions/essay/WrittenEssay.js
+++ b/website/src/components/posts/CollegeAdmissions/essay/WrittenEssay.js
@@ -17,22 +17,22 @@ export default function WrittenEssay(props) {
       />
     )
   );
-  return <div className="essay-section">{sections}</div>;
+  return <p className="essay-section">{sections}</p>;
 }
 
 function PlainSection(props) {
-  return <div className="essay-sentence">{props.text}</div>;
+  return <span className="essay-sentence">{props.text}</span>;
 }
 
 function ChangeableSection(props) {
   return (
-    <div
+    <span
       onClick={props.onClick}
       className={`essay-sentence ${
         props.selected ? "selected-word" : "changeable-word"
       }`}
     >
       {props.text}
-    </div>
+    </span>
   );
 }

--- a/website/src/components/posts/CollegeAdmissions/essay/essay.css
+++ b/website/src/components/posts/CollegeAdmissions/essay/essay.css
@@ -10,9 +10,8 @@
 }
 
 .essay-section {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  margin-left: 5%;
+  margin-right: 5%;
 }
 
 .essay-sentence {


### PR DESCRIPTION
Originally, `essay-section` was a Flex-box container and each individual section of text was wrapped inside of a div. However, since divs actually force separation between each other due to being a block-level element, this caused spacing issues when an especially long piece of text followed a short one.

To fix this issue, `PlainSection` and `ChangeableSection` were changed from being divs to spans, since spans are inline elements.